### PR TITLE
Add search & fetch tools and run server via SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository contains a simple [FastMCP](https://github.com/jlowin/fastmcp) s
 - List Jira boards
 - Create Confluence pages
 - Query OpenAI models
+- Search Confluence content with the `search` tool
+- Fetch full pages with the `fetch` tool
 
 ## Setup
 1. Install dependencies using [uv](https://github.com/astral-sh/uv):
@@ -24,4 +26,4 @@ This repository contains a simple [FastMCP](https://github.com/jlowin/fastmcp) s
 python -m app.main
 ```
 
-The server will start using the default FastMCP HTTP transport.
+The server will start using the FastMCP SSE transport, which is required for OpenAI Agent Mode.

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from .server import mcp
 
 if __name__ == "__main__":
-    mcp.run()
+    # Run the server using SSE transport for OpenAI compatibility
+    mcp.run(transport="sse")

--- a/app/model.py
+++ b/app/model.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass, asdict
+from typing import Optional, Dict
+
+@dataclass
+class SearchResult:
+    """Represents a search result item."""
+    id: str
+    title: str
+    text: str
+    url: str
+
+    def asdict(self) -> Dict:
+        return asdict(self)
+
+@dataclass
+class Document:
+    """Represents full page contents."""
+    id: str
+    title: str
+    text: str
+    url: str
+    metadata: Optional[Dict] = None
+
+    def asdict(self) -> Dict:
+        return asdict(self)

--- a/app/server.py
+++ b/app/server.py
@@ -1,7 +1,10 @@
 from fastmcp.server import FastMCP
 from atlassian import Jira, Confluence
+from bs4 import BeautifulSoup
 import openai
 import os
+
+from .model import SearchResult, Document
 
 mcp = FastMCP(name="FastMCP Atlassian Server")
 
@@ -53,6 +56,47 @@ def ask_openai(prompt: str, model: str = "gpt-4") -> dict:
         messages=[{"role": "user", "content": prompt}]
     )
     return completion
+
+@mcp.tool(title="Search", description="Search Confluence pages")
+def search(query: str, limit: int = 5) -> list:
+    """Search Confluence pages using CQL."""
+    if conf is None:
+        raise RuntimeError("Confluence not configured")
+    response = conf.cql(
+        f'text ~ "{query}"',
+        limit=limit,
+        excerpt="highlight",
+    )
+    results: list[dict] = []
+    for item in response.get("results", []):
+        content = item.get("content", {})
+        snippet_html = item.get("excerpt", "")
+        snippet_text = BeautifulSoup(snippet_html, "html.parser").get_text()
+        sr = SearchResult(
+            id=str(content.get("id")),
+            title=content.get("title", ""),
+            text=snippet_text,
+            url=f"{ATLASSIAN_URL}/wiki{content.get('_links', {}).get('web', '')}",
+        )
+        results.append(sr.asdict())
+    return results
+
+@mcp.tool(title="Fetch", description="Fetch a Confluence page by id")
+def fetch(page_id: str) -> dict:
+    """Fetch a Confluence page by id."""
+    if conf is None:
+        raise RuntimeError("Confluence not configured")
+    page = conf.get_page_by_id(page_id, expand="body.storage,metadata.labels")
+    body_html = page.get("body", {}).get("storage", {}).get("value", "")
+    text = BeautifulSoup(body_html, "html.parser").get_text()
+    doc = Document(
+        id=str(page_id),
+        title=page.get("title", ""),
+        text=text,
+        url=f"{ATLASSIAN_URL}/wiki{page.get('_links', {}).get('web', '')}",
+        metadata={"space": page.get("space", {}).get("key")},
+    )
+    return doc.asdict()
 
 # alias for CLI discovery
 app = mcp


### PR DESCRIPTION
## Summary
- implement search and fetch tools for Confluence
- expose snippets in search results
- run in SSE mode for OpenAI Agent Mode

## Testing
- `python -m app.main & sleep 3; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_6881893dc0e483319121eee36fa59f70