### PR TITLE
Update search tool to use query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a simple [FastMCP](https://github.com/jlowin/fastmcp) s
 - List Jira boards
 - Create Confluence pages
 - Query OpenAI models
-- Search Confluence content with the `search` tool
+- Search Confluence content with the `search` tool using a query string
 - Fetch full pages with the `fetch` tool
 
 ## Setup

--- a/app/server.py
+++ b/app/server.py
@@ -15,22 +15,32 @@ ATLASSIAN_API_TOKEN = os.environ.get("ATLASSIAN_API_TOKEN")
 jira = None
 conf = None
 if ATLASSIAN_URL and ATLASSIAN_USERNAME and ATLASSIAN_API_TOKEN:
-    jira = Jira(url=ATLASSIAN_URL, username=ATLASSIAN_USERNAME, password=ATLASSIAN_API_TOKEN)
-    conf = Confluence(url=ATLASSIAN_URL, username=ATLASSIAN_USERNAME, password=ATLASSIAN_API_TOKEN)
+    jira = Jira(
+        url=ATLASSIAN_URL, username=ATLASSIAN_USERNAME, password=ATLASSIAN_API_TOKEN
+    )
+    conf = Confluence(
+        url=ATLASSIAN_URL, username=ATLASSIAN_USERNAME, password=ATLASSIAN_API_TOKEN
+    )
 
 openai.api_key = os.environ.get("OPENAI_API_KEY")
 
+
 @mcp.tool
-def create_jira_issue(project_key: str, summary: str, description: str, issue_type: str = "Task") -> dict:
+def create_jira_issue(
+    project_key: str, summary: str, description: str, issue_type: str = "Task"
+) -> dict:
     """Create a Jira issue"""
     if jira is None:
         raise RuntimeError("Jira not configured")
-    return jira.issue_create(fields={
-        "project": {"key": project_key},
-        "summary": summary,
-        "description": description,
-        "issuetype": {"name": issue_type}
-    })
+    return jira.issue_create(
+        fields={
+            "project": {"key": project_key},
+            "summary": summary,
+            "description": description,
+            "issuetype": {"name": issue_type},
+        }
+    )
+
 
 @mcp.tool
 def list_jira_boards() -> list:
@@ -39,6 +49,7 @@ def list_jira_boards() -> list:
         raise RuntimeError("Jira not configured")
     return jira.get_all_boards()
 
+
 @mcp.tool
 def create_confluence_page(space: str, title: str, body: str) -> dict:
     """Create a Confluence page"""
@@ -46,27 +57,25 @@ def create_confluence_page(space: str, title: str, body: str) -> dict:
         raise RuntimeError("Confluence not configured")
     return conf.create_page(space=space, title=title, body=body)
 
+
 @mcp.tool
 def ask_openai(prompt: str, model: str = "gpt-4") -> dict:
     """Query an OpenAI model"""
     if not openai.api_key:
         raise RuntimeError("OpenAI API key not configured")
     completion = openai.ChatCompletion.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}]
+        model=model, messages=[{"role": "user", "content": prompt}]
     )
     return completion
 
+
 @mcp.tool(title="Search", description="Search Confluence pages")
 def search(query: str, limit: int = 5) -> list:
-    """Search Confluence pages using CQL."""
+    """Search Confluence pages using a query string."""
     if conf is None:
         raise RuntimeError("Confluence not configured")
-    response = conf.cql(
-        f'text ~ "{query}"',
-        limit=limit,
-        excerpt="highlight",
-    )
+    # Use the generic search endpoint to find pages relevant to the query
+    response = conf.search(str=query, limit=limit, excerpt="highlight")
     results: list[dict] = []
     for item in response.get("results", []):
         content = item.get("content", {})
@@ -80,6 +89,7 @@ def search(query: str, limit: int = 5) -> list:
         )
         results.append(sr.asdict())
     return results
+
 
 @mcp.tool(title="Fetch", description="Fetch a Confluence page by id")
 def fetch(page_id: str) -> dict:
@@ -97,6 +107,7 @@ def fetch(page_id: str) -> dict:
         metadata={"space": page.get("space", {}).get("key")},
     )
     return doc.asdict()
+
 
 # alias for CLI discovery
 app = mcp


### PR DESCRIPTION
## Summary
- use Confluence's generic `search` endpoint in the MCP `search` tool
- update README wording for new search semantics

## Testing
- `black app/server.py`


------
https://chatgpt.com/codex/tasks/task_e_6881aec822b88331ba8a6136b980c9d1